### PR TITLE
A bit of workspace cleanup / simplifications

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,6 @@ async function setupWorkspace() {
 	Environment.set();
 	await workspace.setup();
 	await sdk.ensureInstalled();
-	await workspace.patchLaunchAndTasks();
 	await ensureInstalledBuildchains();
 	await Feedback.infoModal("Workspace has been set up.");
 }
@@ -97,7 +96,6 @@ async function newFromTemplate(template: ContractTemplate) {
 		let contractName = await presenter.askContractName();
 
 		await sdk.newFromTemplate(parentFolder, templateName, contractName);
-		await workspace.patchLaunchAndTasks();
 		await ensureInstalledBuildchains();
 		vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
 	} catch (error) {

--- a/src/presenter.ts
+++ b/src/presenter.ts
@@ -26,12 +26,6 @@ export async function askContractName() {
     return result;
 }
 
-export async function askModifyLaunchAndTasks(): Promise<boolean> {
-    let answer = await askYesNo(`Allow MultiversX IDE to modify this workspace's "launch.json" and "tasks.json"?\n
-For a better experience when debugging Smart Contracts, we recommed allowing this change.`);
-    return answer;
-}
-
 export async function askInstallMxpy(requiredVersion: Version): Promise<boolean> {
     let answer = await askYesNo(`MultiversX IDE requires mxpy ${requiredVersion}, which isn't available in your environment.
 Do you agree to install it?`);

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -140,71 +140,6 @@ export function guardIsOpen(): boolean {
     return true;
 }
 
-export async function patchLaunchAndTasks() {
-    let env = Environment.getForVsCodeFiles();
-    let envJson = JSON.stringify(env);
-
-    let launchPath = path.join(getPath(), ".vscode", "launch.json");
-    writeFileIfMissing(launchPath, `{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "request": "launch",
-            "type": "node",
-            "name": "Dump env",
-            "args": ["-e", "console.log(JSON.stringify(process.env, null, 4))"],
-            "env": ${envJson}
-        }
-    ]
-}`);
-
-    let tasksPath = path.join(getPath(), ".vscode", "tasks.json");
-    writeFileIfMissing(tasksPath, `{
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Dump env",
-            "command": "node",
-            "args": ["-e", "console.log(JSON.stringify(process.env, null, 4))"],
-            "type": "process",
-            "options": {
-                "env": ${envJson}
-            }
-        }
-    ]
-}`);
-
-    let launchObject = JSON.parse(fs.readFileSync(launchPath, { encoding: "utf8" }));
-    let tasksObject = JSON.parse(fs.readFileSync(tasksPath, { encoding: "utf8" }));
-    let launchItems: any[] = launchObject["configurations"];
-    let tasksItems: any[] = tasksObject["tasks"];
-    let patched = false;
-
-    let metadataObjects = getMetadataObjects();
-
-    metadataObjects.forEach(metadata => {
-        let project = metadata.ProjectName;
-        let projectPath = metadata.ProjectPathInWorkspace;
-        let language = metadata.Language;
-
-        // Patch "launchItems" and "tasksItems", if needed (not needed at this moment).
-        // In the past, we've patched both "launchItems" and "tasks" collections.
-    });
-
-    if (!patched) {
-        return;
-    }
-
-    let allow = await presenter.askModifyLaunchAndTasks();
-    if (!allow) {
-        return;
-    }
-
-    fs.writeFileSync(launchPath, JSON.stringify(launchObject, null, 4));
-    fs.writeFileSync(tasksPath, JSON.stringify(tasksObject, null, 4));
-    Feedback.info("Updated launch.json and tasks.json.");
-}
-
 export function getLanguages() {
     let metadataObjects = getMetadataObjects();
     let languagesInProject = metadataObjects.map(item => item.Language);
@@ -264,7 +199,6 @@ function setupGitignore() {
 **/output/**
 **/testnet/**
 **/wallets/**
-**/erdpy.data-storage.json
 **/mxpy.data-storage.json
 **/*.interaction.json
 `);


### PR DESCRIPTION
In the past, we've patched both `launchItems` and `tasks` collections of `launch.json` and `tasks.json`. Now we don't anymore.