### PR TITLE
Fix compatibility with mxpy v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-elrond-ide",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-elrond-ide",
-			"version": "0.18.0",
+			"version": "0.19.0",
 			"dependencies": {
 				"axios": "0.24.0",
 				"glob": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-elrond-ide",
 	"displayName": "MultiversX IDE",
 	"description": "MultiversX IDE for developing Smart Contracts",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"publisher": "Elrond",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -90,18 +90,18 @@
 				"category": "multiversx"
 			},
 			{
-				"command": "multiversx.runFreshTestnet",
-				"title": "Start Fresh Testnet",
+				"command": "multiversx.runFreshLocalnet",
+				"title": "Start Fresh Localnet",
 				"category": "multiversx"
 			},
 			{
-				"command": "multiversx.resumeExistingTestnet",
-				"title": "Resume Testnet",
+				"command": "multiversx.resumeExistingLocalnet",
+				"title": "Resume Localnet",
 				"category": "multiversx"
 			},
 			{
-				"command": "multiversx.stopTestnet",
-				"title": "Stop Testnet",
+				"command": "multiversx.stopLocalnet",
+				"title": "Stop Localnet",
 				"category": "multiversx"
 			}
 		],
@@ -138,19 +138,19 @@
 					"group": "multiversx"
 				},
 				{
-					"command": "multiversx.runFreshTestnet",
-					"when": "resourceFilename == testnet.toml",
-					"group": "multiversx Testnet"
+					"command": "multiversx.runFreshLocalnet",
+					"when": "resourceFilename == localnet.toml",
+					"group": "multiversx Localnet"
 				},
 				{
-					"command": "multiversx.resumeExistingTestnet",
-					"when": "resourceFilename == testnet.toml",
-					"group": "multiversx Testnet"
+					"command": "multiversx.resumeExistingLocalnet",
+					"when": "resourceFilename == localnet.toml",
+					"group": "multiversx Localnet"
 				},
 				{
-					"command": "multiversx.stopTestnet",
-					"when": "resourceFilename == testnet.toml",
-					"group": "multiversx Testnet"
+					"command": "multiversx.stopLocalnet",
+					"when": "resourceFilename == localnet.toml",
+					"group": "multiversx Localnet"
 				}
 			],
 			"commandPalette": [
@@ -183,15 +183,15 @@
 					"when": "false"
 				},
 				{
-					"command": "multiversx.runFreshTestnet",
+					"command": "multiversx.runFreshLocalnet",
 					"when": "false"
 				},
 				{
-					"command": "multiversx.resumeExistingTestnet",
+					"command": "multiversx.resumeExistingLocalnet",
 					"when": "false"
 				},
 				{
-					"command": "multiversx.stopTestnet",
+					"command": "multiversx.stopLocalnet",
 					"when": "false"
 				}
 			],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,9 +28,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand("multiversx.gotoContract", gotoContract);
 	vscode.commands.registerCommand("multiversx.buildContract", buildContract);
 	vscode.commands.registerCommand("multiversx.runScenarios", runScenarios);
-	vscode.commands.registerCommand("multiversx.runFreshTestnet", runFreshTestnet);
-	vscode.commands.registerCommand("multiversx.resumeExistingTestnet", resumeExistingTestnet);
-	vscode.commands.registerCommand("multiversx.stopTestnet", stopTestnet);
+	vscode.commands.registerCommand("multiversx.runFreshLocalnet", runFreshLocalnet);
+	vscode.commands.registerCommand("multiversx.resumeExistingLocalnet", resumeExistingLocalnet);
+	vscode.commands.registerCommand("multiversx.stopLocalnet", stopLocalnet);
 
 	vscode.commands.registerCommand("multiversx.cleanContract", cleanContract);
 	vscode.commands.registerCommand("multiversx.refreshTemplates", async () => await refreshViewModel(templatesViewModel));
@@ -154,25 +154,25 @@ async function runScenarios(item: any) {
 	}
 }
 
-async function runFreshTestnet(testnetToml: Uri) {
+async function runFreshLocalnet(localnetToml: Uri) {
 	try {
-		await sdk.runFreshTestnet(testnetToml);
+		await sdk.runFreshLocalnet(localnetToml);
 	} catch (error) {
 		errors.caughtTopLevel(error);
 	}
 }
 
-async function resumeExistingTestnet(testnetToml: Uri) {
+async function resumeExistingLocalnet(localnetToml: Uri) {
 	try {
-		await sdk.resumeExistingTestnet(testnetToml);
+		await sdk.resumeExistingLocalnet(localnetToml);
 	} catch (error) {
 		errors.caughtTopLevel(error);
 	}
 }
 
-async function stopTestnet(testnetToml: Uri) {
+async function stopLocalnet(localnetToml: Uri) {
 	try {
-		await sdk.stopTestnet(testnetToml);
+		await sdk.stopLocalnet(localnetToml);
 	} catch (error) {
 		errors.caughtTopLevel(error);
 	}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -245,7 +245,7 @@ async function reinstallMxpyGroup(group: string, version: FreeTextVersion) {
 
 export async function buildContract(folder: string) {
     try {
-        await runInTerminal("build", `${Mxpy} --verbose contract build --path "${folder}"`);
+        await runInTerminal("build", `${Mxpy} contract build --path "${folder}"`);
     } catch (error: any) {
         throw new errors.MyError({ Message: "Could not build Smart Contract", Inner: error });
     }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -118,21 +118,6 @@ function getMxpyUpUrl(version: Version) {
     return `https://raw.githubusercontent.com/multiversx/mx-sdk-py-cli/${version.vValue}/mxpy-up.py`;
 }
 
-export async function fetchTemplates(cacheFile: string) {
-    try {
-        await ProcessFacade.execute({
-            program: Mxpy,
-            args: ["contract", "templates"],
-            doNotDumpStdout: true,
-            stdoutToFile: cacheFile
-        });
-
-        Feedback.debug(`Templates fetched, saved to ${cacheFile}.`);
-    } catch (error: any) {
-        throw new errors.MyError({ Message: "Could not fetch templates", Inner: error });
-    }
-}
-
 export async function newFromTemplate(folder: string, template: string, name: string) {
     try {
         await ProcessFacade.execute({

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -12,7 +12,7 @@ import path = require("path");
 import fs = require('fs');
 
 const Mxpy = "mxpy";
-const DefaultMxpyVersion = Version.parse("5.3.2");
+const DefaultMxpyVersion = Version.parse("8.1.0");
 const LatestMxpyReleaseUrl = "https://api.github.com/repos/multiversx/mx-sdk-py-cli/releases/latest";
 
 export function getPath() {
@@ -245,7 +245,7 @@ async function reinstallMxpyGroup(group: string, version: FreeTextVersion) {
 
 export async function buildContract(folder: string) {
     try {
-        await runInTerminal("build", `${Mxpy} --verbose contract build "${folder}"`);
+        await runInTerminal("build", `${Mxpy} --verbose contract build --path "${folder}"`);
     } catch (error: any) {
         throw new errors.MyError({ Message: "Could not build Smart Contract", Inner: error });
     }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,8 +1,90 @@
 import * as vscode from 'vscode';
-import fs = require("fs");
 import path = require("path");
-import * as sdk from "./sdk";
-import * as storage from "./storage";
+
+// Contract templates cannot be fetched from mxpy v8 easily, since the stdout of "mxpy contract templates" includes non-JSON data.
+// Here, we hardcode the list of templates, in expectation of the new way to get the templates (e.g. via "sc-meta" or directly from a file on GitHub).
+const CONTRACT_TEMPLATES = [
+    {
+        "name": "adder",
+        "language": "rust"
+    },
+    {
+        "name": "bonding-curve-contract",
+        "language": "rust"
+    },
+    {
+        "name": "check-pause",
+        "language": "rust"
+    },
+    {
+        "name": "crowdfunding-esdt",
+        "language": "rust"
+    },
+    {
+        "name": "crypto-bubbles",
+        "language": "rust"
+    },
+    {
+        "name": "crypto-zombies",
+        "language": "rust"
+    },
+    {
+        "name": "digital-cash",
+        "language": "rust"
+    },
+    {
+        "name": "empty",
+        "language": "rust"
+    },
+    {
+        "name": "esdt-transfer-with-fee",
+        "language": "rust"
+    },
+    {
+        "name": "factorial",
+        "language": "rust"
+    },
+    {
+        "name": "fractional-nfts",
+        "language": "rust"
+    },
+    {
+        "name": "lottery-esdt",
+        "language": "rust"
+    },
+    {
+        "name": "multisig",
+        "language": "rust"
+    },
+    {
+        "name": "nft-minter",
+        "language": "rust"
+    },
+    {
+        "name": "nft-storage-prepay",
+        "language": "rust"
+    },
+    {
+        "name": "ping-pong-egld",
+        "language": "rust"
+    },
+    {
+        "name": "proxy-pause",
+        "language": "rust"
+    },
+    {
+        "name": "rewards-distribution",
+        "language": "rust"
+    },
+    {
+        "name": "seed-nft-minter",
+        "language": "rust"
+    },
+    {
+        "name": "token-release",
+        "language": "rust"
+    }
+];
 
 export class TemplatesViewModel implements vscode.TreeDataProvider<ContractTemplate> {
     private _onDidChangeTreeData: vscode.EventEmitter<ContractTemplate | undefined> = new vscode.EventEmitter<ContractTemplate | undefined>();
@@ -12,7 +94,6 @@ export class TemplatesViewModel implements vscode.TreeDataProvider<ContractTempl
     }
 
     async refresh() {
-        await sdk.fetchTemplates(this.getCacheFile());
         this._onDidChangeTreeData.fire(null);
     }
 
@@ -25,18 +106,7 @@ export class TemplatesViewModel implements vscode.TreeDataProvider<ContractTempl
             return [];
         }
 
-        let cacheFile = this.getCacheFile();
-        if (!fs.existsSync(cacheFile)) {
-            return [];
-        }
-
-        let templatesJson = fs.readFileSync(cacheFile, { encoding: "utf8" });
-        let templatesPlain = JSON.parse(templatesJson) as any[];
-        return templatesPlain.map(item => new ContractTemplate(item));
-    }
-
-    private getCacheFile(): string {
-        return storage.getPathTo("templates.json");
+        return CONTRACT_TEMPLATES.map(item => new ContractTemplate(item));
     }
 }
 
@@ -64,3 +134,4 @@ export class ContractTemplate {
         };
     }
 }
+


### PR DESCRIPTION
 - Reference mxpy v8.
 - Alter `contract build` command, so that it's compatible with newest `mxpy`. **Compatibility with mxpy v7 is now lost (but this should not be a major issue, generally speaking)**.
 - Hardcode list of contract templates, since they cannot be fetched from `mxpy contract templates` anymore. Furthermore, the new implementation for getting templates (via sc-meta) is expected / awaited / pending.
 - Update integration with `mxpy localnet`. Localnet-related commands are now active if a file called `localnet.toml` is right-clicked.

Should fix: https://github.com/multiversx/mx-ide-vscode/issues/80.